### PR TITLE
fix(首页图片展示): 解决当配置文章自定义img后，由于首页文章列表图片标签不闭合导致文字展示异常的bug

### DIFF
--- a/layout/index.ejs
+++ b/layout/index.ejs
@@ -66,7 +66,7 @@
                         <div class="card-image">
                             <% if (post.img) { %>
                             <!-- <img src="<%= post.img %>" class="responsive-img" alt="<%- post.title %>"> -->
-                            <img src="<%- theme.jsDelivr.url %><%= post.img %>" class="responsive-img" alt="<%- post.title %>"
+                            <img src="<%- theme.jsDelivr.url %><%= post.img %>" class="responsive-img" alt="<%- post.title %>" />
                             <% } else { %>
                             <%
                                 var featureimg = '/medias/featureimages/0.jpg';


### PR DESCRIPTION
图片标签不闭合导致生成的html文章标题展示异常
![image](https://user-images.githubusercontent.com/37357188/149737707-f0eb6eb3-9e13-417f-9155-18e5d17d8f59.png)
